### PR TITLE
fix: resolve remaining type mismatch in confirmation email template

### DIFF
--- a/pb_hooks/views/mail/reservation_confirmation.html
+++ b/pb_hooks/views/mail/reservation_confirmation.html
@@ -58,7 +58,7 @@
     {{ end }}
 </ul>
 
-{{ if gt .deposit_total 0.0 }}
+{{ if gt .deposit_total 0 }}
 <p style="margin-top: 16px; padding: 12px; background-color: #f0f0f0; border-radius: 4px;">
     <strong>Gesamtpfand: €{{ printf "%.2f" .deposit_total }}</strong>
 </p>


### PR DESCRIPTION
The deposit_total comparison still used float 0.0 while the value
arrives as int64 from the JS runtime, causing a Go template panic
that silently prevented all confirmation emails from being sent.

Same class of bug that 4a4454c partially fixed for per-item deposits.

https://claude.ai/code/session_01Jp67bWnu4acqVXooNMstSQ